### PR TITLE
feat: add support for file_uploads

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,11 +1,11 @@
 -pbp               # Start with Perl Best Practices
 --maximum-line-length=120
 --maximum-consecutive-blank-lines=2
---indent-columns=2
+--indent-columns=4
 --opening-brace-always-on-right
 --cuddled-else
 --vertical-tightness=0
---paren-tightness=2
+--paren-tightness=1
 --weld-nested-containers
 --weld-fat-comma
 --extended-continuation-indentation

--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,0 +1,15 @@
+-pbp               # Start with Perl Best Practices
+--maximum-line-length=120
+--maximum-consecutive-blank-lines=2
+--indent-columns=2
+--opening-brace-always-on-right
+--cuddled-else
+--vertical-tightness=0
+--paren-tightness=2
+--weld-nested-containers
+--weld-fat-comma
+--extended-continuation-indentation
+-bom     # keep method chain's linebreaks
+-isbc    # don't indent comments w/o leading space
+--nostandard-output
+--noblanks-before-comments

--- a/lib/OpenAPI/Client/OpenAI.pm
+++ b/lib/OpenAPI/Client/OpenAI.pm
@@ -13,69 +13,75 @@ use Mojo::URL;
 our $VERSION = '0.02';
 
 sub new {
-    my ( $class, $specification ) = ( shift, shift );
-    my $attrs = @_ == 1 ? shift : {@_};
+  my ($class, $specification) = (shift, shift);
+  my $attrs = @_ == 1 ? shift : {@_};
 
-    if ( !$ENV{OPENAI_API_KEY} ) {
-        Carp::croak('OPENAI_API_KEY environment variable must be set');
+  if (!$ENV{OPENAI_API_KEY}) {
+    Carp::croak('OPENAI_API_KEY environment variable must be set');
+  }
+
+  if (!$specification) {
+    eval {
+      $specification = dist_file('OpenAPI-Client-OpenAI', 'openapi.yaml');
+      1;
+    } or do {
+      # Fallback to local share directory during development
+      warn $@;
+      $specification = catfile('share', 'openapi.yaml');
+    };
+  }
+  my %headers = ('Authorization' => "Bearer $ENV{OPENAI_API_KEY}",);
+  if (delete $attrs->{assistants}) {
+    $headers{'OpenAI-Beta'} = 'assistants=v1';
+  }
+
+  # 'message' => 'You must provide the \'OpenAI-Beta\' header to access the
+  # Assistants API. Please try again by setting the header \'OpenAI-Beta:
+  # assistants=v1\'.'
+
+  my $self = $class->SUPER::new($specification, %{$attrs});
+
+  # you use this via $client->createTranscription({}, file_upload => { file => ..., model => ...})
+  $self->ua->transactor->add_generator(
+    file_upload => sub {
+      my ($t, $tx, $data) = @_;
+      return $t->_form($tx, { %$data, file => { content => $data->{file} } });
     }
+  );
 
-    if ( !$specification ) {
-        eval {
-            $specification = dist_file( 'OpenAPI-Client-OpenAI', 'openapi.yaml' );
-            1;
-        } or do {
-            # Fallback to local share directory during development
-            warn $@;
-            $specification = catfile( 'share', 'openapi.yaml' );
-        };
+  $self->ua->on(
+    start => sub {
+      my ($ua, $tx) = @_;
+      foreach my $header (keys %headers) {
+        $tx->req->headers->header($header => $headers{$header});
+      }
     }
-    my %headers = (
-        'Authorization' => "Bearer $ENV{OPENAI_API_KEY}",
-    );
-    if ( delete $attrs->{assistants} ) {
-       $headers{'OpenAI-Beta'} = 'assistants=v1';
-    }
+  );
 
-    # 'message' => 'You must provide the \'OpenAI-Beta\' header to access the
-    # Assistants API. Please try again by setting the header \'OpenAI-Beta:
-    # assistants=v1\'.'
-
-    my $self = $class->SUPER::new( $specification, %{$attrs} );
-
-    $self->ua->on(
-        start => sub {
-            my ( $ua, $tx ) = @_;
-            foreach my $header ( keys %headers ) {
-                $tx->req->headers->header( $header => $headers{$header} );
-            }
-        }
-    );
-
-    return $self;
+  return $self;
 }
 
 # install snake case aliases
 
 {
-    # Do we want to deprecate these? They're kind of a pain to maintain,
-    # or we should autogenerate them from the OpenAPI spec.
-    my %snake_case_alias = (
-        createChatCompletion => 'create_chat_completion',
-        createCompletion     => 'create_completion',
-        createEmbedding      => 'create_embedding',
-        createImage          => 'create_image',
-        createModeration     => 'create_moderation',
-        listModels           => 'list_models',
-    );
+  # Do we want to deprecate these? They're kind of a pain to maintain,
+  # or we should autogenerate them from the OpenAPI spec.
+  my %snake_case_alias = (
+    createChatCompletion => 'create_chat_completion',
+    createCompletion     => 'create_completion',
+    createEmbedding      => 'create_embedding',
+    createImage          => 'create_image',
+    createModeration     => 'create_moderation',
+    listModels           => 'list_models',
+  );
 
-    for my $camel_case_method ( keys %snake_case_alias ) {
-        no strict 'refs';
-        *{"$snake_case_alias{$camel_case_method}"} = sub {
-            my $self = shift;
-            $self->$camel_case_method(@_);
-        }
+  for my $camel_case_method (keys %snake_case_alias) {
+    no strict 'refs';
+    *{"$snake_case_alias{$camel_case_method}"} = sub {
+      my $self = shift;
+      $self->$camel_case_method(@_);
     }
+  }
 }
 
 1;


### PR DESCRIPTION
This PR adds in basic support for file uploads, needed to use the whisper
`createTranscription` endpoint.

The usage is:
```perl
$client->createTranscription({}, file_upload => { file => $file_contents, model => ... })
```

Note the empty hashref at the beggining. We could shake this up a drop, and instead of
manually passing in the contents, have the user pass in a filename which Mojo handles
correctly. 

It may be worth considering generating a method for this that handles the ugly calling
convention, so you could just `$client->createTranscription({ file => $file_contents, model => ...})`
