### PR TITLE
fix: switch to using `file` instead of `content`

### DIFF
--- a/lib/OpenAPI/Client/OpenAI.pm
+++ b/lib/OpenAPI/Client/OpenAI.pm
@@ -41,11 +41,12 @@ sub new {
 
     my $self = $class->SUPER::new( $specification, %{$attrs} );
 
-    # you use this via $client->createTranscription({}, file_upload => { file => ..., model => ...})
+    # you use this via $client->createTranscription({}, file_upload => { file => $filename, model => ...})
+    # note that you pass in a filename, so you don't have to read it yourself
     $self->ua->transactor->add_generator(
         file_upload => sub {
             my ( $t, $tx, $data ) = @_;
-            return $t->_form( $tx, { %$data, file => { content => $data->{file} } } );
+            return $t->_form( $tx, { %$data, file => { file => $data->{file} } } );
         }
     );
 


### PR DESCRIPTION
This is now tested that it works successfully. 

You can use this script to test it
```perl
#!/usr/bin/env perl

use strict;
use warnings;
use lib 'lib';
use OpenAPI::Client::OpenAI;
use Data::Dumper;

my $client = OpenAPI::Client::OpenAI->new;
my $response = $client->createTranscription(
    {},
    file_upload => {
        file     => 'speech.mp3',
        model    => 'whisper-1',
        language => 'en',
    },
);

print Dumper( $response->res );
```
